### PR TITLE
Use platform path separator for ffmpeg path lookup

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -126,7 +126,7 @@ namespace GravadorDeTela
 
             // 3) PATH
             var pathVar = Environment.GetEnvironmentVariable("PATH") ?? "";
-            foreach (var dir in pathVar.Split(';'))
+            foreach (var dir in pathVar.Split(Path.PathSeparator))
             {
                 try
                 {


### PR DESCRIPTION
## Summary
- Replace hardcoded `;` in PATH splitting with `Path.PathSeparator` in `GetFfmpegPath`

## Testing
- `dotnet build` *(fails: BaseOutputPath/OutputPath property is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e454b5288321a08d07159d9f0a48