### PR TITLE
Register Exited handler before checking ffmpeg process

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -463,22 +463,22 @@ namespace GravadorDeTela
 
             try
             {
-                if (!_ffmpegProc.HasExited)
-                {
-                    try { _ffmpegProc.StandardInput.WriteLine("q"); } catch { }
-                }
-
                 var tcs = new TaskCompletionSource<bool>();
                 _ffmpegProc.Exited += (s, e) => tcs.TrySetResult(true);
 
                 if (!_ffmpegProc.HasExited)
                 {
-                    await Task.WhenAny(tcs.Task, Task.Delay(STOP_TIMEOUT_MS));
-                }
+                    try { _ffmpegProc.StandardInput.WriteLine("q"); } catch { }
 
-                if (!_ffmpegProc.HasExited)
-                {
-                    try { _ffmpegProc.Kill(); } catch { }
+                    if (!_ffmpegProc.HasExited)
+                    {
+                        await Task.WhenAny(tcs.Task, Task.Delay(STOP_TIMEOUT_MS));
+
+                        if (!_ffmpegProc.HasExited)
+                        {
+                            try { _ffmpegProc.Kill(); } catch { }
+                        }
+                    }
                 }
             }
             finally


### PR DESCRIPTION
## Summary
- Ensure ffmpeg process exit is captured by registering the `Exited` handler before checking `HasExited`
- Only await process termination and force kill if ffmpeg is still running after signaling quit

## Testing
- `dotnet build GravadorDeTela.sln` *(fails: BaseOutputPath/OutputPath property is not set for project)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e861cc688321aa151a204e468244