### PR TITLE
Add cross-platform logic for opening recording folder

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using System.Runtime.InteropServices;
 
 namespace GravadorDeTela
 {
@@ -138,6 +139,26 @@ namespace GravadorDeTela
             return null;
         }
 
+        private void AbrirPasta(string caminho)
+        {
+            try
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    Process.Start("explorer.exe", caminho);
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    Process.Start("xdg-open", caminho);
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    Process.Start("open", caminho);
+                }
+            }
+            catch { }
+        }
+
         // ==================== LISTAGEM DSHOW ====================
 
         private async Task CarregarDispositivosAudio()
@@ -247,7 +268,7 @@ namespace GravadorDeTela
         {
             if (!string.IsNullOrEmpty(_pastaDaGravacaoAtual) && Directory.Exists(_pastaDaGravacaoAtual))
             {
-                try { Process.Start("explorer.exe", _pastaDaGravacaoAtual); } catch { }
+                AbrirPasta(_pastaDaGravacaoAtual);
             }
             else
             {
@@ -393,7 +414,7 @@ namespace GravadorDeTela
                 _stopAutoCts?.Cancel();
                 await PararFfmpeg();
                 AtualizaStatus("Processamento concluído!", marquee: false);
-                try { Process.Start("explorer.exe", _pastaDaGravacaoAtual); } catch { }
+                AbrirPasta(_pastaDaGravacaoAtual);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- Ensure folder opening uses platform-specific command
- Introduce helper to open folders across Windows, Linux, and macOS

## Testing
- `msbuild GravadorDeTela.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e95c487c83218dd0c1585902d7c2