### PR TITLE
Tratar exceções nos métodos Log e AtualizaStatus

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -73,7 +73,10 @@ namespace GravadorDeTela
                 File.AppendAllText(Path.Combine(raiz, "gravador.log"),
                     $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {msg}{Environment.NewLine}");
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Debug.WriteLine("Erro ao gravar log: " + ex);
+            }
         }
 
         private void AtualizaStatus(string texto, bool marquee = true)
@@ -85,7 +88,10 @@ namespace GravadorDeTela
                 lblStatus.Text = texto;
                 lblStatus.Visible = true;
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Log("Erro ao atualizar status: " + ex);
+            }
         }
 
         private void FinalizarUI()


### PR DESCRIPTION
## Summary
- Substituir catch genérico por captura explícita em Log e AtualizaStatus
- Registrar falhas de log no debug e registrar erros de atualização de status em arquivo

## Testing
- `dotnet build` *(falhou: The BaseOutputPath/OutputPath property is not set for project 'GravadorDeTela.csproj')*

------
https://chatgpt.com/codex/tasks/task_e_68a9ea60be288321ad07597911541ed2