### PR TITLE
Remove Any CPU solution configurations

### DIFF
--- a/GravadorDeTela.sln
+++ b/GravadorDeTela.sln
@@ -7,18 +7,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GravadorDeTela", "GravadorD
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64
-		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{59033CFA-1D58-4D96-B035-E5CDA266B824}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{59033CFA-1D58-4D96-B035-E5CDA266B824}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{59033CFA-1D58-4D96-B035-E5CDA266B824}.Debug|x64.ActiveCfg = Debug|x64
 		{59033CFA-1D58-4D96-B035-E5CDA266B824}.Debug|x64.Build.0 = Debug|x64
-		{59033CFA-1D58-4D96-B035-E5CDA266B824}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{59033CFA-1D58-4D96-B035-E5CDA266B824}.Release|Any CPU.Build.0 = Release|Any CPU
 		{59033CFA-1D58-4D96-B035-E5CDA266B824}.Release|x64.ActiveCfg = Release|x64
 		{59033CFA-1D58-4D96-B035-E5CDA266B824}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- Remove Any CPU configurations from solution to ensure only x64 build profiles

## Testing
- `dotnet build GravadorDeTela.sln` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ec1939ac832198f19a6aa0835e6e