### PR TITLE
Add wall clock timestamp flag to FFmpeg inputs

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -336,12 +336,12 @@ namespace GravadorDeTela
                 _pastaDaGravacaoAtual = CriarDiretorioGravavel();
 
                 // montar argumentos FFmpeg
-                string videoIn = $"-rtbufsize 256M -f gdigrab -draw_mouse 1 -framerate {FPS} -i desktop";
+                string videoIn = $"-rtbufsize 256M -f gdigrab -draw_mouse 1 -framerate {FPS} -use_wallclock_as_timestamps 1 -i desktop";
 
                 // usar moniker se existir, senão o nome amigável
                 string audioId = !string.IsNullOrWhiteSpace(dev.Moniker) ? dev.Moniker : dev.DisplayName;
                 // Atenção: moniker contém barra invertida → precisa escapar as aspas apenas.
-                string audioIn = $"-f dshow -thread_queue_size 1024 -i audio=\"{audioId}\"";
+                string audioIn = $"-f dshow -thread_queue_size 1024 -use_wallclock_as_timestamps 1 -i audio=\"{audioId}\"";
 
                 string map = "-map 0:v -map 1:a -shortest ";
 


### PR DESCRIPTION
## Summary
- add `-use_wallclock_as_timestamps 1` to both video and audio input options
- ensure final ffmpeg argument string includes the updated inputs

## Testing
- `xbuild` *(fails: Invalid -langversion option `7.3`)*

------
https://chatgpt.com/codex/tasks/task_e_68a9eeb1dae48321bb1c81a55f1f6b20