### PR TITLE
Ajusta opções de áudio fixas no ffmpeg

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -420,11 +420,11 @@ namespace GravadorDeTela
                 // usar moniker se existir, senão o nome amigável
                 string audioId = !string.IsNullOrWhiteSpace(dev.Moniker) ? dev.Moniker : dev.DisplayName;
                 // Atenção: moniker contém barra invertida → precisa escapar as aspas apenas.
-                string audioIn = $"-f dshow -audio_buffer_size 100 -rtbufsize 64M -thread_queue_size {THREAD_QUEUE_SIZE} -use_wallclock_as_timestamps 1 -i audio=\"{audioId}\"";
+                string audioIn = $"-f dshow -audio_buffer_size 100 -rtbufsize 64M -thread_queue_size {THREAD_QUEUE_SIZE} -i audio=\"{audioId}\"";
 
                 string map = "-map 0:v -map 1:a -shortest ";
 
-                string audioOpts = "-af aresample=async=1:first_pts=0 -c:a aac -b:a " + AUDIO_KBPS + "k ";
+                string audioOpts = "-af aresample=async=1:first_pts=0 -ac 2 -ar 44100 -c:a aac -b:a " + AUDIO_KBPS + "k ";
                 string argsSaida;
                 if (chkModoWhatsApp.Checked)
                 {


### PR DESCRIPTION
## Summary
- remove uso de `-use_wallclock_as_timestamps` ao capturar áudio
- define canais e taxa de amostragem fixos nas opções de áudio

## Testing
- `xbuild GravadorDeTela.csproj` *(fails: Invalid -langversion option `7.3`)*

------
https://chatgpt.com/codex/tasks/task_e_68ab37b15c008321b641d947e920c2c6