### PR TITLE
Adiciona flag de timestamps na captura de áudio

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -420,7 +420,7 @@ namespace GravadorDeTela
                 // usar moniker se existir, senão o nome amigável
                 string audioId = !string.IsNullOrWhiteSpace(dev.Moniker) ? dev.Moniker : dev.DisplayName;
                 // Atenção: moniker contém barra invertida → precisa escapar as aspas apenas.
-                string audioIn = $"-f dshow -audio_buffer_size 100 -rtbufsize 64M -thread_queue_size {THREAD_QUEUE_SIZE} -i audio=\"{audioId}\"";
+                string audioIn = $"-f dshow -audio_buffer_size 100 -rtbufsize 64M -thread_queue_size {THREAD_QUEUE_SIZE} -use_wallclock_as_timestamps 1 -i audio=\"{audioId}\"";
 
                 string map = "-map 0:v -map 1:a -shortest ";
 


### PR DESCRIPTION
## Resumo
- Inclui `-use_wallclock_as_timestamps 1` na construção do parâmetro `audioIn`

## Testes
- `xbuild GravadorDeTela.sln` *(falha: CSC: error CS1617 - Invalid -langversion option `7.3`)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3e5777208321a89a85be453add0f