### PR TITLE
Add audio delay option and offset audio input in FFmpeg

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -42,6 +42,9 @@
             this.cmbAudio = new System.Windows.Forms.ComboBox();
             this.label3 = new System.Windows.Forms.Label();
             this.label4 = new System.Windows.Forms.Label();
+            this.numDelay = new System.Windows.Forms.NumericUpDown();
+            this.label5 = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)(this.numDelay)).BeginInit();
             this.SuspendLayout();
             // 
             // label1
@@ -163,19 +166,52 @@
             this.label3.Text = "Escolha o audio de captura:";
             // 
             // label4
-            // 
+            //
             this.label4.AutoSize = true;
             this.label4.Location = new System.Drawing.Point(-2, 313);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(55, 13);
             this.label4.TabIndex = 14;
             this.label4.Text = "para LoLo";
-            // 
+            //
+            // numDelay
+            //
+            this.numDelay.Increment = new decimal(new int[] {
+            100,
+            0,
+            0,
+            0});
+            this.numDelay.Location = new System.Drawing.Point(480, 267);
+            this.numDelay.Maximum = new decimal(new int[] {
+            10000,
+            0,
+            0,
+            0});
+            this.numDelay.Minimum = new decimal(new int[] {
+            10000,
+            0,
+            0,
+            -2147483648});
+            this.numDelay.Name = "numDelay";
+            this.numDelay.Size = new System.Drawing.Size(72, 20);
+            this.numDelay.TabIndex = 15;
+            //
+            // label5
+            //
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(334, 269);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(105, 13);
+            this.label5.TabIndex = 16;
+            this.label5.Text = "Atraso do áudio (ms):";
+            //
             // Form1
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(615, 326);
+            this.Controls.Add(this.label5);
+            this.Controls.Add(this.numDelay);
             this.Controls.Add(this.label4);
             this.Controls.Add(this.label3);
             this.Controls.Add(this.cmbAudio);
@@ -192,6 +228,7 @@
             this.Controls.Add(this.label1);
             this.Name = "Form1";
             this.Text = "Form1";
+            ((System.ComponentModel.ISupportInitialize)(this.numDelay)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -213,6 +250,8 @@
         private System.Windows.Forms.ComboBox cmbAudio;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.NumericUpDown numDelay;
+        private System.Windows.Forms.Label label5;
     }
 }
 

--- a/Form1.cs
+++ b/Form1.cs
@@ -108,6 +108,7 @@ namespace GravadorDeTela
             txtSegmentacao.Enabled = chkModoWhatsApp.Checked;
             chkStop.Enabled = true;
             txtStop.Enabled = chkStop.Checked;
+            numDelay.Enabled = true;
         }
 
         private string CriarDiretorioGravavel()
@@ -420,7 +421,9 @@ namespace GravadorDeTela
                 // usar moniker se existir, senão o nome amigável
                 string audioId = !string.IsNullOrWhiteSpace(dev.Moniker) ? dev.Moniker : dev.DisplayName;
                 // Atenção: moniker contém barra invertida → precisa escapar as aspas apenas.
-                string audioIn = $"-f dshow -audio_buffer_size 100 -rtbufsize 64M -thread_queue_size {THREAD_QUEUE_SIZE} -use_wallclock_as_timestamps 1 -i audio=\"{audioId}\"";
+                int delayMs = (int)numDelay.Value;
+                string offsetArg = delayMs == 0 ? string.Empty : $"-itsoffset {(delayMs / 1000.0).ToString(CultureInfo.InvariantCulture)} ";
+                string audioIn = offsetArg + $"-f dshow -audio_buffer_size 100 -rtbufsize 64M -thread_queue_size {THREAD_QUEUE_SIZE} -use_wallclock_as_timestamps 1 -i audio=\"{audioId}\"";
 
                 string map = "-map 0:v -map 1:a -shortest ";
 
@@ -480,6 +483,7 @@ namespace GravadorDeTela
                 chkStop.Enabled = false;
                 txtStop.Enabled = false;
                 txtSegmentacao.Enabled = false;
+                numDelay.Enabled = false;
                 this.Cursor = Cursors.WaitCursor;
                 AtualizaStatus("Iniciando gravação...");
             }


### PR DESCRIPTION
## Summary
- Add numeric delay field to UI so users can offset audio capture in milliseconds
- Inject `-itsoffset` before audio input when building FFmpeg command

## Testing
- `dotnet build` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*
- `ffprobe -v error -show_entries stream=index,codec_type,start_time -of default=noprint_wrappers=1 out_pos.mp4`
- `ffprobe -v error -select_streams a -show_packets -of csv out_neg.mp4 | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68ab4014ded08321847ef006b78b9e52