### PR TITLE
Corrige filtro de áudio para evitar atraso acumulado

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -427,7 +427,7 @@ namespace GravadorDeTela
 
                 string map = "-map 0:v -map 1:a -shortest ";
 
-                string audioOpts = "-af aresample=async=1:first_pts=0 -ac 2 -ar 44100 -c:a aac -b:a " + AUDIO_KBPS + "k ";
+                string audioOpts = "-af aresample=async=1:min_hard_comp=0.1:first_pts=0 -ac 2 -ar 44100 -c:a aac -b:a " + AUDIO_KBPS + "k ";
                 string argsSaida;
                 if (chkModoWhatsApp.Checked)
                 {


### PR DESCRIPTION
## Resumo
- Ajusta `audioOpts` para usar filtro `aresample` com `min_hard_comp` e `first_pts` para sincronizar áudio em gravações longas.

## Testes
- `dotnet build` *(falhou: The reference assemblies for .NETFramework,Version=v4.8 were not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ab41f26fc48321a042232028a72c08