### PR TITLE
Increase default FPS to 60

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -15,7 +15,7 @@ namespace GravadorDeTela
     public partial class Form1 : Form
     {
         // ===== Configurações padrão =====
-        private const int FPS = 24;
+        private const int FPS = 60;
         private const int VIDEO_CRF = 23;
         private const int AUDIO_KBPS = 192;
         private const int PADRAO_SEGUNDOS_WHATSAPP = 120; // padrão se não informado


### PR DESCRIPTION
## Summary
- bump default recording frame rate to 60 FPS

## Testing
- `xbuild GravadorDeTela.sln` *(fails: CSC: error CS1617: Invalid -langversion option `7.3`...)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5963bc0c8321926d68288ff24a53