### PR TITLE
Resolve Timer ambiguity in Form1

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Runtime.InteropServices;
 using ScreenRecorderLib;
+using WinFormsTimer = System.Windows.Forms.Timer;
 
 namespace GravadorDeTela
 {
@@ -28,7 +29,7 @@ namespace GravadorDeTela
         private string _pastaDaGravacaoAtual;
         private CancellationTokenSource _stopAutoCts;
         private Recorder _recorder;
-        private Timer _segmentTimer;
+        private WinFormsTimer _segmentTimer;
         private int _segmentIndex;
         private int _audioDelayMs;
 
@@ -476,7 +477,7 @@ namespace GravadorDeTela
 
                 if (chkModoWhatsApp.Checked)
                 {
-                    _segmentTimer = new Timer();
+                    _segmentTimer = new WinFormsTimer();
                     _segmentTimer.Interval = segmentSeconds * 1000;
                     _segmentTimer.Tick += (s2, e2) =>
                     {


### PR DESCRIPTION
## Summary
- Alias System.Windows.Forms.Timer to avoid conflict with System.Threading.Timer
- Update timer declaration and initialization to use the new alias

## Testing
- `dotnet build` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5d77917883218eceb0967e0c19fe