### PR TITLE
Atualiza VideoOptions para VideoEncoderOptions

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -437,7 +437,7 @@ namespace GravadorDeTela
                         IsAudioEnabled = true,
                         AudioOutputDevice = dev.DisplayName
                     },
-                    VideoOptions = new VideoOptions
+                    VideoEncoderOptions = new VideoEncoderOptions
                     {
                         Framerate = FPS,
                         Quality = VIDEO_CRF


### PR DESCRIPTION
## Summary
- adapta inicialização do ScreenRecorderLib para usar VideoEncoderOptions em vez de VideoOptions

## Testing
- `dotnet build` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5ed56bb48321b7c0faee5d9ffcc4