### PR TITLE
Reduce default FPS to 30

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -16,7 +16,7 @@ namespace GravadorDeTela
     public partial class Form1 : Form
     {
         // ===== Configurações padrão =====
-        private const int FPS = 60;
+        private const int FPS = 30;
         private const int VIDEO_CRF = 23;
         private const int AUDIO_KBPS = 192;
         private const int PADRAO_SEGUNDOS_WHATSAPP = 120; // padrão se não informado

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # GravadorDeTela
+
+Ferramenta de gravação de tela com foco em computadores fracos. O FPS padrão é 30 para reduzir travamentos em máquinas modestas.
+


### PR DESCRIPTION
## Summary
- lower default recording frame rate to 30 FPS for better performance on low-end machines
- document new FPS default in README

## Testing
- `dotnet build` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab64fc0c788321bf663b4a0102bf1c