### PR TITLE
Corrigir reinício de segmentação de vídeo

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -457,8 +457,11 @@ namespace GravadorDeTela
                     {
                         _segmentIndex++;
                         string next = Path.Combine(_pastaDaGravacaoAtual, $"Parte_{_segmentIndex:000}.mp4");
-                        _recorder.Record(next);
-                        _segmentTimer.Start();
+                        this.BeginInvoke((MethodInvoker)(() =>
+                        {
+                            _recorder.Record(next);
+                            _segmentTimer.Start();
+                        }));
                     }
                     else
                     {


### PR DESCRIPTION
## Summary
- Garantir que gravações segmentadas reiniciem o timer no thread da UI

## Testing
- `msbuild GravadorDeTela.sln` *(falhou: comando não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68acbc8be51c8321ac19132a15f13fda