### PR TITLE
Allow adjusting video quality

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -44,6 +44,9 @@
             this.label4 = new System.Windows.Forms.Label();
             this.txtAudioDelay = new System.Windows.Forms.TextBox();
             this.label5 = new System.Windows.Forms.Label();
+            this.label6 = new System.Windows.Forms.Label();
+            this.numQuality = new System.Windows.Forms.NumericUpDown();
+            ((System.ComponentModel.ISupportInitialize)(this.numQuality)).BeginInit();
             this.SuspendLayout();
             // 
             // label1
@@ -190,11 +193,44 @@
             this.label5.TabIndex = 16;
             this.label5.Text = "Atraso do áudio (ms):";
             //
+            // label6
+            //
+            this.label6.AutoSize = true;
+            this.label6.Location = new System.Drawing.Point(334, 217);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(104, 13);
+            this.label6.TabIndex = 17;
+            this.label6.Text = "Qualidade do vídeo:";
+            //
+            // numQuality
+            //
+            this.numQuality.Location = new System.Drawing.Point(480, 215);
+            this.numQuality.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            0});
+            this.numQuality.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.numQuality.Name = "numQuality";
+            this.numQuality.Size = new System.Drawing.Size(72, 20);
+            this.numQuality.TabIndex = 18;
+            this.numQuality.Value = new decimal(new int[] {
+            70,
+            0,
+            0,
+            0});
+            //
             // Form1
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(615, 326);
+            this.Controls.Add(this.label6);
+            this.Controls.Add(this.numQuality);
             this.Controls.Add(this.label5);
             this.Controls.Add(this.txtAudioDelay);
             this.Controls.Add(this.label4);
@@ -213,6 +249,7 @@
             this.Controls.Add(this.label1);
             this.Name = "Form1";
             this.Text = "Form1";
+            ((System.ComponentModel.ISupportInitialize)(this.numQuality)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -236,6 +273,8 @@
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.TextBox txtAudioDelay;
         private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.NumericUpDown numQuality;
     }
 }
 

--- a/Form1.cs
+++ b/Form1.cs
@@ -17,7 +17,7 @@ namespace GravadorDeTela
     {
         // ===== Configurações padrão =====
         private const int FPS = 30;
-        private const int VIDEO_CRF = 23;
+        private const int VIDEO_QUALITY_PADRAO = 70;
         private const int AUDIO_KBPS = 192;
         private const int PADRAO_SEGUNDOS_WHATSAPP = 120; // padrão se não informado
         private const int MIN_SEGUNDOS_WHATSAPP = 15;
@@ -65,6 +65,7 @@ namespace GravadorDeTela
             txtSegmentacao.Enabled = chkModoWhatsApp.Checked;
             txtStop.Enabled = chkStop.Checked;
             txtAudioDelay.Text = Properties.Settings.Default.AudioDelay.ToString();
+            numQuality.Value = VIDEO_QUALITY_PADRAO;
 
             // Carregar dispositivos de áudio dshow
             Shown += async (s, e) => await CarregarDispositivosAudio();
@@ -440,7 +441,7 @@ namespace GravadorDeTela
                     VideoEncoderOptions = new VideoEncoderOptions
                     {
                         Framerate = FPS,
-                        Quality = VIDEO_CRF
+                        Quality = (int)numQuality.Value
                     }
                 };
 

--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 Ferramenta de gravação de tela com foco em computadores fracos. O FPS padrão é 30 para reduzir travamentos em máquinas modestas.
 
+É possível ajustar a **qualidade do vídeo** (1–100) diretamente pela interface; o padrão é 70.
+


### PR DESCRIPTION
## Summary
- add NumericUpDown and label to pick video quality (1-100)
- use selected quality when configuring ScreenRecorder
- document new video quality option in README

## Testing
- `dotnet build` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ca027d108321ab14d934a27c313c