### PR TITLE
Add Windows build and release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,48 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - 'v*'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '7.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: msbuild GravadorDeTela.sln /p:Configuration=Release
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: GravadorDeTela
+          path: bin/x64/Release/
+
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    runs-on: windows-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: GravadorDeTela
+          path: release
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: release/**/*


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to build project on Windows, restore dependencies, and publish release artifacts

## Testing
- `dotnet restore GravadorDeTela.sln`
- `dotnet build GravadorDeTela.sln` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b892cf8c048321ab22a5a105817704