### PR TITLE
Ignore demo.git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ installer/
 
 # Arquivos de configuração do usuário do Visual Studio
 .vs/
+demo.git


### PR DESCRIPTION
## Summary
- ensure demo.git is ignored so it doesn't get reintroduced

## Testing
- `dotnet build` *(fails: reference assemblies for .NET Framework v4.8 not found)*
- `git push` *(fails: no configured push destination)*

------
https://chatgpt.com/codex/tasks/task_e_68b899140d4483218d9d0107e43a24ae