### PR TITLE
Rename video quality field and clarify quality slider

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -197,7 +197,7 @@
             //
             this.trkQualidade.Location = new System.Drawing.Point(15, 197);
             this.trkQualidade.Maximum = 100;
-            this.trkQualidade.Minimum = 0;
+            this.trkQualidade.Minimum = 1;
             this.trkQualidade.Name = "trkQualidade";
             this.trkQualidade.Size = new System.Drawing.Size(221, 45);
             this.trkQualidade.TabIndex = 17;
@@ -208,9 +208,9 @@
             this.lblQualidadeValor.AutoSize = true;
             this.lblQualidadeValor.Location = new System.Drawing.Point(242, 209);
             this.lblQualidadeValor.Name = "lblQualidadeValor";
-            this.lblQualidadeValor.Size = new System.Drawing.Size(19, 13);
+            this.lblQualidadeValor.Size = new System.Drawing.Size(116, 13);
             this.lblQualidadeValor.TabIndex = 18;
-            this.lblQualidadeValor.Text = "60";
+            this.lblQualidadeValor.Text = "Qualidade (1-100): 60";
             //
             // Form1
             //

--- a/Form1.cs
+++ b/Form1.cs
@@ -17,7 +17,7 @@ namespace GravadorDeTela
     {
         // ===== Configurações padrão =====
         private const int FPS = 30;
-        private int _videoQualityCrf = 60;
+        private int _videoQuality = 60;
         private const int AUDIO_KBPS = 192;
         private const int PADRAO_SEGUNDOS_WHATSAPP = 120; // padrão se não informado
         private const int MIN_SEGUNDOS_WHATSAPP = 15;
@@ -66,8 +66,8 @@ namespace GravadorDeTela
             txtStop.Enabled = chkStop.Checked;
             txtAudioDelay.Text = Properties.Settings.Default.AudioDelay.ToString();
 
-            trkQualidade.Value = _videoQualityCrf;
-            lblQualidadeValor.Text = _videoQualityCrf.ToString();
+            trkQualidade.Value = _videoQuality;
+            lblQualidadeValor.Text = $"Qualidade (1-100): {_videoQuality}";
             trkQualidade.Scroll += trkQualidade_Scroll;
 
             // Carregar dispositivos de áudio dshow
@@ -76,8 +76,8 @@ namespace GravadorDeTela
 
         private void trkQualidade_Scroll(object sender, EventArgs e)
         {
-            _videoQualityCrf = trkQualidade.Value;
-            lblQualidadeValor.Text = _videoQualityCrf.ToString();
+            _videoQuality = trkQualidade.Value;
+            lblQualidadeValor.Text = $"Qualidade (1-100): {_videoQuality}";
         }
 
         // ==================== UTILITÁRIOS ====================
@@ -450,7 +450,7 @@ namespace GravadorDeTela
                     VideoEncoderOptions = new VideoEncoderOptions
                     {
                         Framerate = FPS,
-                        Quality = _videoQualityCrf
+                        Quality = _videoQuality
                     }
                 };
 


### PR DESCRIPTION
## Summary
- Rename `_videoQualityCrf` to `_videoQuality` and update references
- Limit quality slider to 1–100 and display current value with label
- Ensure recorder options use new `_videoQuality` field

## Testing
- `xbuild` *(fails: Invalid -langversion option `7.3`)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1f1b4ac08321a5285822e7e9f089