### PR TITLE
Add LoloRecorder WPF project with recording libraries

### DIFF
--- a/GravadorDeTela.sln
+++ b/GravadorDeTela.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.11.35312.102
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GravadorDeTela", "GravadorDeTela.csproj", "{59033CFA-1D58-4D96-B035-E5CDA266B824}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LoloRecorder", "LoloRecorder\LoloRecorder.csproj", "{49505756-CFB6-4F67-AAAD-73D5B5ACB06E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -15,6 +17,10 @@ Global
 		{59033CFA-1D58-4D96-B035-E5CDA266B824}.Debug|x64.Build.0 = Debug|x64
 		{59033CFA-1D58-4D96-B035-E5CDA266B824}.Release|x64.ActiveCfg = Release|x64
 		{59033CFA-1D58-4D96-B035-E5CDA266B824}.Release|x64.Build.0 = Release|x64
+                {49505756-CFB6-4F67-AAAD-73D5B5ACB06E}.Debug|x64.ActiveCfg = Debug|x64
+                {49505756-CFB6-4F67-AAAD-73D5B5ACB06E}.Debug|x64.Build.0 = Debug|x64
+                {49505756-CFB6-4F67-AAAD-73D5B5ACB06E}.Release|x64.ActiveCfg = Release|x64
+                {49505756-CFB6-4F67-AAAD-73D5B5ACB06E}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/LoloRecorder/App.xaml
+++ b/LoloRecorder/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="LoloRecorder.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/LoloRecorder/App.xaml.cs
+++ b/LoloRecorder/App.xaml.cs
@@ -1,0 +1,8 @@
+using System.Windows;
+
+namespace LoloRecorder
+{
+    public partial class App : Application
+    {
+    }
+}

--- a/LoloRecorder/LoloRecorder.csproj
+++ b/LoloRecorder/LoloRecorder.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="ScreenRecorderLib" Version="6.5.0" />
+    <PackageReference Include="SharpAvi" Version="3.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\RecursosExternos\ffmpeg.exe">
+      <Link>RecursosExternos\ffmpeg.exe</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/LoloRecorder/MainWindow.xaml
+++ b/LoloRecorder/MainWindow.xaml
@@ -1,0 +1,7 @@
+<Window x:Class="LoloRecorder.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="LoloRecorder" Height="350" Width="525">
+    <Grid>
+    </Grid>
+</Window>

--- a/LoloRecorder/MainWindow.xaml.cs
+++ b/LoloRecorder/MainWindow.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace LoloRecorder
+{
+    public partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add LoloRecorder WPF project targeting .NET 6
- include ScreenRecorderLib and SharpAvi packages with ffmpeg resource
- register LoloRecorder in solution build configurations

## Testing
- `msbuild GravadorDeTela.sln /t:Restore` *(fails: command not found)*
- `dotnet build GravadorDeTela.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2279428083218a167dbf6f529555