### PR TITLE
Adiciona layout básico de gravação com cores globais

### DIFF
--- a/LoloRecorder/MainWindow.xaml
+++ b/LoloRecorder/MainWindow.xaml
@@ -2,6 +2,37 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="LoloRecorder" Height="350" Width="525">
-    <Grid>
+    <Window.Resources>
+        <ResourceDictionary>
+            <!-- Global color resources -->
+            <SolidColorBrush x:Key="Fundo" Color="#1e1e1e"/>
+            <SolidColorBrush x:Key="Acento" Color="#0a84ff"/>
+
+            <!-- Global button style -->
+            <Style TargetType="Button">
+                <Setter Property="Background" Value="{StaticResource Acento}"/>
+                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Padding" Value="10,5"/>
+                <Setter Property="Margin" Value="0,5"/>
+            </Style>
+
+            <!-- Toggle button style for Record/Stop -->
+            <Style x:Key="ToggleRecordButtonStyle" TargetType="ToggleButton" BasedOn="{StaticResource {x:Type Button}}">
+                <Setter Property="Content" Value="Gravar"/>
+                <Style.Triggers>
+                    <Trigger Property="IsChecked" Value="True">
+                        <Setter Property="Content" Value="Parar"/>
+                        <Setter Property="Background" Value="Red"/>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+        </ResourceDictionary>
+    </Window.Resources>
+    <Grid Background="{StaticResource Fundo}">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Width="200">
+            <ToggleButton x:Name="RecordToggle" Style="{StaticResource ToggleRecordButtonStyle}"/>
+            <ComboBox x:Name="AudioDevicesCombo" Margin="0,5"/>
+            <Label x:Name="StatusLabel" Content="Parado" Foreground="{StaticResource Acento}" HorizontalAlignment="Center"/>
+        </StackPanel>
     </Grid>
 </Window>


### PR DESCRIPTION
## Sumário
- define cores globais e estilo de botões
- adiciona layout central com botão Gravar/Parar, seleção de áudio e status

## Testes
- `dotnet build` *(falhou: Microsoft.NET.Sdk.WindowsDesktop não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68bb27f783348321827dabbea97bbd05