### PR TITLE
Toggle screen recording control

### DIFF
--- a/LoloRecorder/MainWindow.xaml
+++ b/LoloRecorder/MainWindow.xaml
@@ -30,7 +30,10 @@
     </Window.Resources>
     <Grid Background="{StaticResource Fundo}">
         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Width="200">
-            <ToggleButton x:Name="RecordToggle" Style="{StaticResource ToggleRecordButtonStyle}"/>
+            <ToggleButton x:Name="RecordToggle"
+                          Style="{StaticResource ToggleRecordButtonStyle}"
+                          Checked="RecordToggle_Checked"
+                          Unchecked="RecordToggle_Unchecked"/>
             <ComboBox x:Name="AudioDevicesCombo" Margin="0,5"/>
             <Label x:Name="StatusLabel" Content="Parado" Foreground="{StaticResource Acento}" HorizontalAlignment="Center"/>
         </StackPanel>

--- a/LoloRecorder/MainWindow.xaml.cs
+++ b/LoloRecorder/MainWindow.xaml.cs
@@ -1,12 +1,54 @@
+using System;
+using System.IO;
 using System.Windows;
+using LoloRecorder.Services;
 
 namespace LoloRecorder
 {
     public partial class MainWindow : Window
     {
+        private readonly ScreenRecorderService _recorderService;
+
         public MainWindow()
         {
             InitializeComponent();
+            var outputPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "gravacao.mp4");
+            _recorderService = new ScreenRecorderService(outputPath);
+        }
+
+        private async void RecordToggle_Checked(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                await _recorderService.StartAsync();
+                StatusLabel.Content = "Gravando...";
+            }
+            catch (Exception ex)
+            {
+                StatusLabel.Content = "Erro ao iniciar";
+                RecordToggle.IsChecked = false;
+                MessageBox.Show(ex.Message, "Erro", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private async void RecordToggle_Unchecked(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                await _recorderService.StopAsync();
+                StatusLabel.Content = "Parado";
+            }
+            catch (Exception ex)
+            {
+                StatusLabel.Content = "Erro ao parar";
+                MessageBox.Show(ex.Message, "Erro", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        protected override async void OnClosed(EventArgs e)
+        {
+            await _recorderService.DisposeAsync();
+            base.OnClosed(e);
         }
     }
 }


### PR DESCRIPTION
## Summary
- hook up ScreenRecorderService to main window toggle button
- update status label when recording starts or stops

## Testing
- `dotnet build LoloRecorder/LoloRecorder.csproj -p:EnableWindowsTargeting=true` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb28f1ebc083219505afc017d3ff86