### PR TITLE
Refactor startup and global resources

### DIFF
--- a/LoloRecorder/App.xaml
+++ b/LoloRecorder/App.xaml
@@ -1,7 +1,11 @@
 <Application x:Class="LoloRecorder.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             StartupUri="MainWindow.xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Resources/Colors.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/LoloRecorder/App.xaml.cs
+++ b/LoloRecorder/App.xaml.cs
@@ -1,8 +1,15 @@
 using System.Windows;
+using LoloRecorder.Views;
 
 namespace LoloRecorder
 {
     public partial class App : Application
     {
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+            var mainWindow = new MainWindow();
+            mainWindow.Show();
+        }
     }
 }

--- a/LoloRecorder/Resources/Colors.xaml
+++ b/LoloRecorder/Resources/Colors.xaml
@@ -1,0 +1,5 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <SolidColorBrush x:Key="Fundo" Color="#1e1e1e"/>
+    <SolidColorBrush x:Key="Acento" Color="#0a84ff"/>
+</ResourceDictionary>

--- a/LoloRecorder/Views/MainWindow.xaml
+++ b/LoloRecorder/Views/MainWindow.xaml
@@ -1,13 +1,9 @@
-<Window x:Class="LoloRecorder.MainWindow"
+<Window x:Class="LoloRecorder.Views.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="LoloRecorder" Height="350" Width="525">
     <Window.Resources>
         <ResourceDictionary>
-            <!-- Global color resources -->
-            <SolidColorBrush x:Key="Fundo" Color="#1e1e1e"/>
-            <SolidColorBrush x:Key="Acento" Color="#0a84ff"/>
-
             <!-- Global button style -->
             <Style TargetType="Button">
                 <Setter Property="Background" Value="{StaticResource Acento}"/>

--- a/LoloRecorder/Views/MainWindow.xaml.cs
+++ b/LoloRecorder/Views/MainWindow.xaml.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Windows;
 using LoloRecorder.Services;
 
-namespace LoloRecorder
+namespace LoloRecorder.Views
 {
     public partial class MainWindow : Window
     {


### PR DESCRIPTION
## Summary
- Merge color resources into global application dictionary
- Start `MainWindow` programmatically on app startup
- Move view files into `Views` folder for clearer structure

## Testing
- `dotnet build` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2a5ba9408321b791898190524453