### PR TITLE
Specify x64 platform target for LoloRecorder

### DIFF
--- a/LoloRecorder/LoloRecorder.csproj
+++ b/LoloRecorder/LoloRecorder.csproj
@@ -3,6 +3,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ScreenRecorderLib" Version="6.5.0" />


### PR DESCRIPTION
## Summary
- add PlatformTarget x64 to LoloRecorder project

## Testing
- `dotnet build LoloRecorder/LoloRecorder.csproj -p:EnableWindowsTargeting=true` *(fails: Could not resolve SDK 'Microsoft.NET.Sdk.WindowsDesktop')*

------
https://chatgpt.com/codex/tasks/task_e_68bb2e1b96188321a06289be3b48af2e