### PR TITLE
Remove obsolete numQuality assignment

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -71,8 +71,6 @@ namespace GravadorDeTela
             txtStop.Enabled = chkStop.Checked;
             cmbMicrofone.Enabled = chkMicrofone.Checked;
             txtAudioDelay.Text = Properties.Settings.Default.AudioDelay.ToString();
-            numQuality.Value = VIDEO_QUALITY_PADRAO;
-
             trkQualidade.Value = _videoQuality;
             lblQualidadeValor.Text = $"Qualidade (1-100): {_videoQuality}";
             trkQualidade.Scroll += trkQualidade_Scroll;


### PR DESCRIPTION
## Summary
- rely on `trkQualidade` for initial video quality and remove unused `numQuality` reference

## Testing
- `xbuild /p:LangVersion=7.2 GravadorDeTela.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68bb2dddc02883219d7b07d2555084d6