### PR TITLE
Enable self-contained publish for LoloRecorder

### DIFF
--- a/LoloRecorder/LoloRecorder.csproj
+++ b/LoloRecorder/LoloRecorder.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <PlatformTarget>x64</PlatformTarget>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ScreenRecorderLib" Version="6.5.0" />


### PR DESCRIPTION
## Summary
- produce win-x64 self-contained single-file build for LoloRecorder

## Testing
- `dotnet publish -c Release -p:EnableWindowsTargeting=true -p:Platform=x64`
- `ls LoloRecorder/bin/Release/net6.0-windows/win-x64/publish`


------
https://chatgpt.com/codex/tasks/task_e_68bb32c85b9c83218f6554cde5f49eb1