### PR TITLE
Fix button styles to use ButtonBase

### DIFF
--- a/LoloRecorder/Views/MainWindow.xaml
+++ b/LoloRecorder/Views/MainWindow.xaml
@@ -5,7 +5,7 @@
     <Window.Resources>
         <ResourceDictionary>
             <!-- Global button style -->
-            <Style TargetType="Button">
+            <Style TargetType="ButtonBase">
                 <Setter Property="Background" Value="{StaticResource Acento}"/>
                 <Setter Property="Foreground" Value="White"/>
                 <Setter Property="Padding" Value="10,5"/>
@@ -13,7 +13,7 @@
             </Style>
 
             <!-- Toggle button style for Record/Stop -->
-            <Style x:Key="ToggleRecordButtonStyle" TargetType="ToggleButton" BasedOn="{StaticResource {x:Type Button}}">
+            <Style x:Key="ToggleRecordButtonStyle" TargetType="ToggleButton" BasedOn="{StaticResource {x:Type ButtonBase}}">
                 <Setter Property="Content" Value="Gravar"/>
                 <Style.Triggers>
                     <Trigger Property="IsChecked" Value="True">


### PR DESCRIPTION
## Summary
- Use ButtonBase for global button style
- Base ToggleRecordButtonStyle on ButtonBase

## Testing
- `dotnet build -p:EnableWindowsTargeting=true -p:Platform=x64`
- `dotnet run -p:EnableWindowsTargeting=true -p:Platform=x64` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bb34b18f488321b7b292476b22e6ee