### PR TITLE
Set explicit x64 platform for LoloRecorder

### DIFF
--- a/LoloRecorder/LoloRecorder.csproj
+++ b/LoloRecorder/LoloRecorder.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
+    <Platforms>x64</Platforms>
     <PlatformTarget>x64</PlatformTarget>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>


### PR DESCRIPTION
## Summary
- switch WPF project to Microsoft.NET.Sdk and explicitly target x64

## Testing
- `dotnet build LoloRecorder/LoloRecorder.csproj -c Debug` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3934d17c8321ac9da0000503c23d