### PR TITLE
Improve recording error handling

### DIFF
--- a/LoloRecorder/Views/MainWindow.xaml.cs
+++ b/LoloRecorder/Views/MainWindow.xaml.cs
@@ -20,14 +20,21 @@ namespace LoloRecorder.Views
         {
             try
             {
-                await _recorderService.StartAsync();
+                var (success, error) = await _recorderService.StartAsync();
+                if (!success)
+                {
+                    StatusLabel.Content = "Erro ao iniciar";
+                    RecordToggle.IsChecked = false;
+                    MessageBox.Show(error ?? "Falha desconhecida ao iniciar gravação.", "Erro", MessageBoxButton.OK, MessageBoxImage.Error);
+                    return;
+                }
                 StatusLabel.Content = "Gravando...";
             }
             catch (Exception ex)
             {
                 StatusLabel.Content = "Erro ao iniciar";
                 RecordToggle.IsChecked = false;
-                MessageBox.Show(ex.Message, "Erro", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show($"Falha inesperada ao iniciar a gravação: {ex.Message}", "Erro", MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
 
@@ -41,7 +48,7 @@ namespace LoloRecorder.Views
             catch (Exception ex)
             {
                 StatusLabel.Content = "Erro ao parar";
-                MessageBox.Show(ex.Message, "Erro", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show($"Falha inesperada ao encerrar a gravação: {ex.Message}", "Erro", MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
 


### PR DESCRIPTION
## Summary
- handle start errors in ScreenRecorderService by creating output folder and returning details
- show friendly messages on start/stop failures

## Testing
- `dotnet build` *(fails: The imported project Microsoft.NET.Sdk.WindowsDesktop.targets was not found; reference assemblies for .NETFramework,Version=v4.8 were not found)*
- `dotnet run --project LoloRecorder` *(fails: The imported project Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb487b682c8321a829f639ea4f75fe