### PR TITLE
Customize WPF MainWindow with manual title bar

### DIFF
--- a/LoloRecorder/Views/MainWindow.xaml
+++ b/LoloRecorder/Views/MainWindow.xaml
@@ -1,7 +1,8 @@
 <Window x:Class="LoloRecorder.Views.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="LoloRecorder" Height="350" Width="525">
+        Title="LoloRecorder" Height="350" Width="525"
+        WindowStyle="None" ResizeMode="NoResize">
     <Window.Resources>
         <ResourceDictionary>
             <!-- Global button style -->
@@ -25,7 +26,30 @@
         </ResourceDictionary>
     </Window.Resources>
     <Grid Background="{StaticResource Fundo}">
-        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Width="200">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="40"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <!-- Custom top bar -->
+        <Border Grid.Row="0" Background="{StaticResource Acento}" MouseDown="TopBar_MouseDown">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Text="LoloRecorder" VerticalAlignment="Center" Margin="10,0" FontWeight="Bold"/>
+
+                <StackPanel Grid.Column="1" Orientation="Horizontal">
+                    <Button x:Name="SettingsButton" Content="⚙" Width="40" Click="SettingsButton_Click"/>
+                    <Button x:Name="MinimizeButton" Content="-" Width="40" Click="MinimizeButton_Click"/>
+                    <Button x:Name="CloseButton" Content="X" Width="40" Click="CloseButton_Click"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <StackPanel Grid.Row="1" HorizontalAlignment="Center" VerticalAlignment="Center" Width="200">
             <ToggleButton x:Name="RecordToggle"
                           Style="{StaticResource ToggleRecordButtonStyle}"
                           Checked="RecordToggle_Checked"

--- a/LoloRecorder/Views/MainWindow.xaml.cs
+++ b/LoloRecorder/Views/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Windows;
+using System.Windows.Input;
 using LoloRecorder.Services;
 
 namespace LoloRecorder.Views
@@ -56,6 +57,29 @@ namespace LoloRecorder.Views
         {
             await _recorderService.DisposeAsync();
             base.OnClosed(e);
+        }
+
+        private void TopBar_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (e.ChangedButton == MouseButton.Left)
+            {
+                DragMove();
+            }
+        }
+
+        private void MinimizeButton_Click(object sender, RoutedEventArgs e)
+        {
+            SystemCommands.MinimizeWindow(this);
+        }
+
+        private void CloseButton_Click(object sender, RoutedEventArgs e)
+        {
+            SystemCommands.CloseWindow(this);
+        }
+
+        private void SettingsButton_Click(object sender, RoutedEventArgs e)
+        {
+            MessageBox.Show("Configurações ainda não implementadas.", "Configurações", MessageBoxButton.OK, MessageBoxImage.Information);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Remove default window chrome and create custom top bar
- Add logo text, settings, minimize and close buttons
- Handle drag, minimize and close events in MainWindow code-behind

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4bcd26408321907a9256d095839a