### PR TITLE
feat: add webcam overlay option

### DIFF
--- a/LoloRecorder/Services/ScreenRecorderService.cs
+++ b/LoloRecorder/Services/ScreenRecorderService.cs
@@ -39,7 +39,8 @@ namespace LoloRecorder.Services
                 {
                     Framerate = 30,
                     Quality = 60
-                }
+                },
+                OverlayOptions = new OverLayOptions()
             };
         }
 
@@ -49,7 +50,7 @@ namespace LoloRecorder.Services
         /// <returns>
         /// Tupla indicando sucesso e mensagem de erro (quando houver).
         /// </returns>
-        public Task<(bool Success, string? ErrorMessage)> StartAsync(RecordingMode mode)
+        public Task<(bool Success, string? ErrorMessage)> StartAsync(RecordingMode mode, string? webcamDevice = null)
         {
             if (_recorder != null)
                 return Task.FromResult<(bool, string?)>((false, "Gravação já iniciada."));
@@ -63,6 +64,18 @@ namespace LoloRecorder.Services
                 }
 
                 var options = _options;
+                options.OverlayOptions ??= new OverLayOptions();
+                options.OverlayOptions.Overlays.Clear();
+                if (!string.IsNullOrWhiteSpace(webcamDevice))
+                {
+                    options.OverlayOptions.Overlays.Add(new VideoCaptureOverlay
+                    {
+                        DeviceName = webcamDevice,
+                        AnchorPoint = Anchor.BottomRight,
+                        Offset = new ScreenSize(10, 10),
+                        Size = new ScreenSize(0, 200)
+                    });
+                }
                 switch (mode)
                 {
                     case RecordingMode.Janela:

--- a/LoloRecorder/Views/MainWindow.xaml
+++ b/LoloRecorder/Views/MainWindow.xaml
@@ -62,6 +62,8 @@
                               Unchecked="RecordToggle_Unchecked"/>
             </StackPanel>
             <ComboBox x:Name="AudioDevicesCombo" Margin="0,5"/>
+            <ToggleButton x:Name="WebcamToggle" Content="Webcam" Margin="0,5" Checked="WebcamToggle_Checked" Unchecked="WebcamToggle_Unchecked"/>
+            <ComboBox x:Name="WebcamDevicesCombo" Margin="0,5" Visibility="Collapsed" DisplayMemberPath="FriendlyName" SelectedValuePath="DeviceName"/>
             <Label x:Name="StatusLabel" Content="Parado" Foreground="{StaticResource Acento}" HorizontalAlignment="Center"/>
         </StackPanel>
     </Grid>

--- a/LoloRecorder/Views/MainWindow.xaml.cs
+++ b/LoloRecorder/Views/MainWindow.xaml.cs
@@ -1,8 +1,10 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Windows;
 using System.Windows.Input;
 using LoloRecorder.Services;
+using ScreenRecorderLib;
 
 namespace LoloRecorder.Views
 {
@@ -28,7 +30,12 @@ namespace LoloRecorder.Views
                     _ => RecordingMode.TelaInteira
                 };
 
-                var (success, error) = await _recorderService.StartAsync(mode);
+                string? webcamDevice = null;
+                if (WebcamToggle.IsChecked == true && WebcamDevicesCombo.SelectedItem is RecordableCamera cam)
+                {
+                    webcamDevice = cam.DeviceName;
+                }
+                var (success, error) = await _recorderService.StartAsync(mode, webcamDevice);
                 if (!success)
                 {
                     StatusLabel.Content = "Erro ao iniciar";
@@ -87,6 +94,20 @@ namespace LoloRecorder.Views
         private void SettingsButton_Click(object sender, RoutedEventArgs e)
         {
             MessageBox.Show("Configurações ainda não implementadas.", "Configurações", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+
+        private void WebcamToggle_Checked(object sender, RoutedEventArgs e)
+        {
+            var devices = Recorder.GetSystemVideoCaptureDevices().ToList();
+            WebcamDevicesCombo.ItemsSource = devices;
+            WebcamDevicesCombo.Visibility = Visibility.Visible;
+            if (devices.Count > 0)
+                WebcamDevicesCombo.SelectedIndex = 0;
+        }
+
+        private void WebcamToggle_Unchecked(object sender, RoutedEventArgs e)
+        {
+            WebcamDevicesCombo.Visibility = Visibility.Collapsed;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add UI toggle and device picker for webcam
- allow ScreenRecorderService to overlay selected camera feed

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb75dc8ee0832181622baaa928f5df