### PR TITLE
Add cursor visibility toggle and output folder selection

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -48,6 +48,10 @@
             this.lblQualidadeValor = new System.Windows.Forms.Label();
             this.chkMicrofone = new System.Windows.Forms.CheckBox();
             this.cmbMicrofone = new System.Windows.Forms.ComboBox();
+            this.chkMostrarCursor = new System.Windows.Forms.CheckBox();
+            this.txtPastaSaida = new System.Windows.Forms.TextBox();
+            this.btnPastaSaida = new System.Windows.Forms.Button();
+            this.label6 = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.trkQualidade)).BeginInit();
             this.SuspendLayout();
             // 
@@ -235,11 +239,54 @@
             this.cmbMicrofone.Size = new System.Drawing.Size(121, 21);
             this.cmbMicrofone.TabIndex = 20;
             //
+            // chkMostrarCursor
+            //
+            this.chkMostrarCursor.AutoSize = true;
+            this.chkMostrarCursor.Checked = true;
+            this.chkMostrarCursor.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkMostrarCursor.Location = new System.Drawing.Point(337, 195);
+            this.chkMostrarCursor.Name = "chkMostrarCursor";
+            this.chkMostrarCursor.Size = new System.Drawing.Size(96, 17);
+            this.chkMostrarCursor.TabIndex = 21;
+            this.chkMostrarCursor.Text = "Mostrar cursor";
+            this.chkMostrarCursor.UseVisualStyleBackColor = true;
+            //
+            // label6
+            //
+            this.label6.AutoSize = true;
+            this.label6.Location = new System.Drawing.Point(12, 183);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(79, 13);
+            this.label6.TabIndex = 22;
+            this.label6.Text = "Pasta de saída:";
+            //
+            // txtPastaSaida
+            //
+            this.txtPastaSaida.Location = new System.Drawing.Point(97, 180);
+            this.txtPastaSaida.Name = "txtPastaSaida";
+            this.txtPastaSaida.ReadOnly = true;
+            this.txtPastaSaida.Size = new System.Drawing.Size(270, 20);
+            this.txtPastaSaida.TabIndex = 23;
+            //
+            // btnPastaSaida
+            //
+            this.btnPastaSaida.Location = new System.Drawing.Point(373, 178);
+            this.btnPastaSaida.Name = "btnPastaSaida";
+            this.btnPastaSaida.Size = new System.Drawing.Size(85, 23);
+            this.btnPastaSaida.TabIndex = 24;
+            this.btnPastaSaida.Text = "Escolher...";
+            this.btnPastaSaida.UseVisualStyleBackColor = true;
+            this.btnPastaSaida.Click += new System.EventHandler(this.btnPastaSaida_Click);
+            //
             // Form1
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(615, 326);
+            this.Controls.Add(this.btnPastaSaida);
+            this.Controls.Add(this.txtPastaSaida);
+            this.Controls.Add(this.label6);
+            this.Controls.Add(this.chkMostrarCursor);
             this.Controls.Add(this.cmbMicrofone);
             this.Controls.Add(this.chkMicrofone);
             this.Controls.Add(this.lblQualidadeValor);
@@ -290,6 +337,10 @@
         private System.Windows.Forms.Label lblQualidadeValor;
         private System.Windows.Forms.CheckBox chkMicrofone;
         private System.Windows.Forms.ComboBox cmbMicrofone;
+        private System.Windows.Forms.CheckBox chkMostrarCursor;
+        private System.Windows.Forms.TextBox txtPastaSaida;
+        private System.Windows.Forms.Button btnPastaSaida;
+        private System.Windows.Forms.Label label6;
     }
 }
 

--- a/Form1.cs
+++ b/Form1.cs
@@ -81,6 +81,7 @@ namespace GravadorDeTela
             trkQualidade.Value = _videoQuality;
             lblQualidadeValor.Text = $"Qualidade (1-100): {_videoQuality}";
             trkQualidade.Scroll += trkQualidade_Scroll;
+            txtPastaSaida.Text = Properties.Settings.Default.OutputFolder;
 
             // Carregar dispositivos de áudio dshow
             Shown += async (s, e) => await CarregarDispositivosAudio();
@@ -145,8 +146,12 @@ namespace GravadorDeTela
 
         private string CriarDiretorioGravavel()
         {
-            var baseVideos = Environment.GetFolderPath(Environment.SpecialFolder.MyVideos);
-            var raiz = Path.Combine(baseVideos, "GravadorDeTela");
+            var raiz = Properties.Settings.Default.OutputFolder;
+            if (string.IsNullOrWhiteSpace(raiz) || !Directory.Exists(raiz))
+            {
+                var baseVideos = Environment.GetFolderPath(Environment.SpecialFolder.MyVideos);
+                raiz = Path.Combine(baseVideos, "GravadorDeTela");
+            }
             Directory.CreateDirectory(raiz);
             string nome = $"Gravacao_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}";
             var destino = Path.Combine(raiz, nome);
@@ -435,6 +440,23 @@ namespace GravadorDeTela
             }
         }
 
+        private void btnPastaSaida_Click(object sender, EventArgs e)
+        {
+            using (var dlg = new FolderBrowserDialog())
+            {
+                dlg.Description = "Selecione a pasta de saída";
+                dlg.SelectedPath = string.IsNullOrWhiteSpace(Properties.Settings.Default.OutputFolder)
+                    ? Environment.GetFolderPath(Environment.SpecialFolder.MyVideos)
+                    : Properties.Settings.Default.OutputFolder;
+                if (dlg.ShowDialog() == DialogResult.OK)
+                {
+                    Properties.Settings.Default.OutputFolder = dlg.SelectedPath;
+                    Properties.Settings.Default.Save();
+                    txtPastaSaida.Text = dlg.SelectedPath;
+                }
+            }
+        }
+
         private void btnIniciar_Click(object sender, EventArgs e)
         {
             try
@@ -528,6 +550,10 @@ namespace GravadorDeTela
                     {
                         Framerate = FPS,
                         Quality = _videoQuality
+                    },
+                    MouseOptions = new MouseOptions
+                    {
+                        IsMousePointerEnabled = chkMostrarCursor.Checked
                     }
                 };
 

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -34,5 +34,17 @@ namespace GravadorDeTela.Properties {
                 this["AudioDelay"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string OutputFolder {
+            get {
+                return ((string)(this["OutputFolder"]));
+            }
+            set {
+                this["OutputFolder"] = value;
+            }
+        }
     }
 }

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -7,5 +7,8 @@
     <Setting Name="AudioDelay" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
+    <Setting Name="OutputFolder" Type="System.String" Scope="User">
+      <Value Profile="(Default)"></Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
## Summary
- allow choosing and persisting recording output folder
- add checkbox to toggle cursor capture
- pass new options into RecorderOptions and file path builder

## Testing
- `dotnet build` *(fails: The imported project "Microsoft.NET.Sdk.WindowsDesktop/targets..." was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb778ef0448321a0dab244f48dd7bf