### PR TITLE
Adicionar hotkeys globais para controle de gravação

### DIFF
--- a/LoloRecorder/Services/ScreenRecorderService.cs
+++ b/LoloRecorder/Services/ScreenRecorderService.cs
@@ -25,6 +25,8 @@ namespace LoloRecorder.Services
         private int _segmentIndex = 1;
         private int _splitSeconds;
         private string _currentOutputPath = string.Empty;
+        public bool IsPaused { get; private set; }
+        public bool IsRecording => _recorder != null;
 
         /// <summary>
         /// Cria uma nova instância do serviço.
@@ -160,6 +162,23 @@ namespace LoloRecorder.Services
             _stopAfterCts?.Cancel();
             _stopAfterCts = null;
             await StopCurrentSegmentAsync();
+            IsPaused = false;
+        }
+
+        public void Pause()
+        {
+            if (_recorder == null || IsPaused)
+                return;
+            _recorder.Pause();
+            IsPaused = true;
+        }
+
+        public void Resume()
+        {
+            if (_recorder == null || !IsPaused)
+                return;
+            _recorder.Resume();
+            IsPaused = false;
         }
 
         private void StartRecorder(string path)

--- a/LoloRecorder/Views/MainWindow.xaml.cs
+++ b/LoloRecorder/Views/MainWindow.xaml.cs
@@ -1,8 +1,10 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Input;
+using System.Windows.Interop;
 using LoloRecorder.Services;
 using ScreenRecorderLib;
 
@@ -11,12 +13,35 @@ namespace LoloRecorder.Views
     public partial class MainWindow : Window
     {
         private readonly ScreenRecorderService _recorderService;
+        private HwndSource? _hwndSource;
+        private IntPtr _windowHandle;
+        private bool _isPaused;
+
+        private const int HOTKEY_START_PAUSE_ID = 1;
+        private const int HOTKEY_STOP_ID = 2;
+        private const int WM_HOTKEY = 0x0312;
+
+        [DllImport("user32.dll")]
+        private static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+
+        [DllImport("user32.dll")]
+        private static extern bool UnregisterHotKey(IntPtr hWnd, int id);
 
         public MainWindow()
         {
             InitializeComponent();
             var outputPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "gravacao.mp4");
             _recorderService = new ScreenRecorderService(outputPath);
+        }
+
+        protected override void OnSourceInitialized(EventArgs e)
+        {
+            base.OnSourceInitialized(e);
+            _windowHandle = new WindowInteropHelper(this).Handle;
+            _hwndSource = HwndSource.FromHwnd(_windowHandle);
+            _hwndSource.AddHook(HwndHook);
+            RegisterHotKey(_windowHandle, HOTKEY_START_PAUSE_ID, 0, (uint)KeyInterop.VirtualKeyFromKey(Key.F8));
+            RegisterHotKey(_windowHandle, HOTKEY_STOP_ID, 0, (uint)KeyInterop.VirtualKeyFromKey(Key.F9));
         }
 
         private async void RecordToggle_Checked(object sender, RoutedEventArgs e)
@@ -69,6 +94,7 @@ namespace LoloRecorder.Views
                     return;
                 }
                 StatusLabel.Content = "Gravando...";
+                _isPaused = false;
             }
             catch (Exception ex)
             {
@@ -84,6 +110,7 @@ namespace LoloRecorder.Views
             {
                 await _recorderService.StopAsync();
                 StatusLabel.Content = "Parado";
+                _isPaused = false;
             }
             catch (Exception ex)
             {
@@ -94,8 +121,61 @@ namespace LoloRecorder.Views
 
         protected override async void OnClosed(EventArgs e)
         {
+            if (_hwndSource != null)
+                _hwndSource.RemoveHook(HwndHook);
+            UnregisterHotKey(_windowHandle, HOTKEY_START_PAUSE_ID);
+            UnregisterHotKey(_windowHandle, HOTKEY_STOP_ID);
             await _recorderService.DisposeAsync();
             base.OnClosed(e);
+        }
+
+        private IntPtr HwndHook(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            if (msg == WM_HOTKEY)
+            {
+                var id = wParam.ToInt32();
+                if (id == HOTKEY_START_PAUSE_ID)
+                {
+                    ToggleRecordingHotkey();
+                    handled = true;
+                }
+                else if (id == HOTKEY_STOP_ID)
+                {
+                    StopRecordingHotkey();
+                    handled = true;
+                }
+            }
+            return IntPtr.Zero;
+        }
+
+        private void ToggleRecordingHotkey()
+        {
+            if (RecordToggle.IsChecked != true)
+            {
+                RecordToggle.IsChecked = true;
+                _isPaused = false;
+            }
+            else if (!_isPaused)
+            {
+                _recorderService.Pause();
+                _isPaused = true;
+                StatusLabel.Content = "Pausado";
+            }
+            else
+            {
+                _recorderService.Resume();
+                _isPaused = false;
+                StatusLabel.Content = "Gravando...";
+            }
+        }
+
+        private void StopRecordingHotkey()
+        {
+            if (RecordToggle.IsChecked == true || _isPaused)
+            {
+                RecordToggle.IsChecked = false;
+                _isPaused = false;
+            }
         }
 
         private void TopBar_MouseDown(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
## Resumo
- Registrar hotkeys globais F8/F9 no `MainWindow` para iniciar/pausar e parar a gravação
- Liberar hotkeys ao encerrar a aplicação
- Expor métodos e estados de pausa no `ScreenRecorderService`

## Testes
- `dotnet build LoloRecorder/LoloRecorder.csproj` *(falhou: dotnet não instalado)*
- `apt-get install -y dotnet-sdk-7.0` *(falhou: pacote não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7dd00e788321b58ada0836ca6486