### PR TITLE
refactor: alias System.Timers.Timer

### DIFF
--- a/LoloRecorder/Services/ScreenRecorderService.cs
+++ b/LoloRecorder/Services/ScreenRecorderService.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Timers;
+using Timer = System.Timers.Timer;
 using ScreenRecorderLib;
 
 namespace LoloRecorder.Services


### PR DESCRIPTION
## Summary
- alias `System.Timers.Timer` to `Timer` for clarity in `ScreenRecorderService`

## Testing
- `dotnet build` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc257225088321977c2f5c2926de9e