### PR TITLE
Enable nullable reference types for LoloRecorder

### DIFF
--- a/LoloRecorder/LoloRecorder.csproj
+++ b/LoloRecorder/LoloRecorder.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
     <PlatformTarget>x64</PlatformTarget>


### PR DESCRIPTION
## Summary
- enable nullable reference types in LoloRecorder project

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc29d99e2083218fcd65d56fcbd93a