### PR TITLE
Remover referências obsoletas a controle de qualidade

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -71,7 +71,6 @@ namespace GravadorDeTela
             txtStop.Enabled = chkStop.Checked;
             cmbMicrofone.Enabled = chkMicrofone.Checked;
             txtAudioDelay.Text = Properties.Settings.Default.AudioDelay.ToString();
-            numQuality.Value = VIDEO_QUALITY_PADRAO;
 
             trkQualidade.Value = _videoQuality;
             lblQualidadeValor.Text = $"Qualidade (1-100): {_videoQuality}";


### PR DESCRIPTION
## Summary
- remove reference to missing quality control and constant
- rely on existing trackbar value for default video quality

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69358988236c83218265e503ecfac292)