### PR TITLE
Corrige cursor de espera infinito durante gravação

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -586,8 +586,10 @@ namespace GravadorDeTela
                 txtStop.Enabled = false;
                 txtSegmentacao.Enabled = false;
                 txtAudioDelay.Enabled = false;
-                this.Cursor = Cursors.WaitCursor;
-                AtualizaStatus("Iniciando gravação...");
+
+                // A gravação já foi iniciada; mantém o cursor normal para não parecer "travado".
+                this.Cursor = Cursors.Default;
+                AtualizaStatus("Gravando...", marquee: false);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
### Motivation
- Usuários relataram que o ponteiro do mouse aparenta ficar travado em um estado de loading infinito durante a gravação, causando confusão apesar do mouse continuar funcional.

### Description
- Modifica `Form1.cs` para remover o uso de `Cursors.WaitCursor` ao iniciar a gravação e passa a usar `Cursors.Default`, além de atualizar o status inicial para `AtualizaStatus("Gravando...", marquee: false)` para exibir feedback contínuo em vez de carregamento.

### Testing
- Tentativas de build automáticas foram executadas com `dotnet build GravadorDeTela.sln` e `msbuild GravadorDeTela.sln /t:Build /p:Configuration=Release`, ambas falharam no ambiente por ausência das ferramentas (`dotnet` / `msbuild` não instalados).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699398450d708321935833eebb9678a5)