### PR TITLE
Melhora interface: atalhos globais e opção de ocultar durante gravação

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -48,44 +48,56 @@
             this.lblQualidadeValor = new System.Windows.Forms.Label();
             this.chkMicrofone = new System.Windows.Forms.CheckBox();
             this.cmbMicrofone = new System.Windows.Forms.ComboBox();
+            this.chkOcultarAoGravar = new System.Windows.Forms.CheckBox();
+            this.lblAtalhos = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.trkQualidade)).BeginInit();
             this.SuspendLayout();
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 21.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.Location = new System.Drawing.Point(118, 9);
+            this.label1.Font = new System.Drawing.Font("Segoe UI Semibold", 20.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.ForeColor = System.Drawing.Color.White;
+            this.label1.Location = new System.Drawing.Point(12, 15);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(242, 33);
+            this.label1.Size = new System.Drawing.Size(286, 37);
             this.label1.TabIndex = 0;
-            this.label1.Text = "Gravador de Tela";
+            this.label1.Text = "Gravador de Tela Pro";
             // 
             // btnIniciar
             // 
-            this.btnIniciar.Location = new System.Drawing.Point(151, 66);
+            this.btnIniciar.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnIniciar.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnIniciar.ForeColor = System.Drawing.Color.White;
+            this.btnIniciar.Location = new System.Drawing.Point(19, 66);
             this.btnIniciar.Name = "btnIniciar";
-            this.btnIniciar.Size = new System.Drawing.Size(108, 38);
+            this.btnIniciar.Size = new System.Drawing.Size(180, 38);
             this.btnIniciar.TabIndex = 1;
-            this.btnIniciar.Text = "Iniciar";
+            this.btnIniciar.Text = "Iniciar gravação (F8)";
             this.btnIniciar.UseVisualStyleBackColor = true;
             this.btnIniciar.Click += new System.EventHandler(this.btnIniciar_Click);
             // 
             // btnParar
             // 
-            this.btnParar.Location = new System.Drawing.Point(328, 66);
+            this.btnParar.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnParar.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnParar.ForeColor = System.Drawing.Color.White;
+            this.btnParar.Location = new System.Drawing.Point(213, 66);
             this.btnParar.Name = "btnParar";
-            this.btnParar.Size = new System.Drawing.Size(108, 38);
+            this.btnParar.Size = new System.Drawing.Size(180, 38);
             this.btnParar.TabIndex = 2;
-            this.btnParar.Text = "Parar";
+            this.btnParar.Text = "Parar gravação (F9)";
             this.btnParar.UseVisualStyleBackColor = true;
             this.btnParar.Click += new System.EventHandler(this.btnParar_Click);
             // 
             // button1
             // 
-            this.button1.Location = new System.Drawing.Point(479, 291);
+            this.button1.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.button1.Font = new System.Drawing.Font("Segoe UI", 9F);
+            this.button1.ForeColor = System.Drawing.Color.White;
+            this.button1.Location = new System.Drawing.Point(462, 321);
             this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(122, 26);
+            this.button1.Size = new System.Drawing.Size(139, 29);
             this.button1.TabIndex = 3;
             this.button1.Text = "Abrir Pasta";
             this.button1.UseVisualStyleBackColor = true;
@@ -96,7 +108,8 @@
             this.chkModoWhatsApp.AutoSize = true;
             this.chkModoWhatsApp.Checked = true;
             this.chkModoWhatsApp.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkModoWhatsApp.Location = new System.Drawing.Point(11, 243);
+            this.chkModoWhatsApp.ForeColor = System.Drawing.Color.White;
+            this.chkModoWhatsApp.Location = new System.Drawing.Point(19, 250);
             this.chkModoWhatsApp.Name = "chkModoWhatsApp";
             this.chkModoWhatsApp.Size = new System.Drawing.Size(248, 17);
             this.chkModoWhatsApp.TabIndex = 4;
@@ -105,16 +118,17 @@
             // 
             // progressBar1
             // 
-            this.progressBar1.Location = new System.Drawing.Point(12, 127);
+            this.progressBar1.Location = new System.Drawing.Point(19, 156);
             this.progressBar1.Name = "progressBar1";
-            this.progressBar1.Size = new System.Drawing.Size(591, 23);
+            this.progressBar1.Size = new System.Drawing.Size(582, 23);
             this.progressBar1.TabIndex = 5;
             // 
             // lblStatus
             // 
             this.lblStatus.AutoSize = true;
-            this.lblStatus.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblStatus.Location = new System.Drawing.Point(12, 165);
+            this.lblStatus.Font = new System.Drawing.Font("Segoe UI", 11.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblStatus.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(98)))), ((int)(((byte)(218)))), ((int)(((byte)(251)))));
+            this.lblStatus.Location = new System.Drawing.Point(19, 182);
             this.lblStatus.Name = "lblStatus";
             this.lblStatus.Size = new System.Drawing.Size(0, 20);
             this.lblStatus.TabIndex = 6;
@@ -122,7 +136,8 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(33, 263);
+            this.label2.ForeColor = System.Drawing.Color.White;
+            this.label2.Location = new System.Drawing.Point(42, 272);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(148, 13);
             this.label2.TabIndex = 7;
@@ -130,14 +145,14 @@
             // 
             // txtSegmentacao
             // 
-            this.txtSegmentacao.Location = new System.Drawing.Point(186, 260);
+            this.txtSegmentacao.Location = new System.Drawing.Point(196, 269);
             this.txtSegmentacao.Name = "txtSegmentacao";
             this.txtSegmentacao.Size = new System.Drawing.Size(72, 20);
             this.txtSegmentacao.TabIndex = 8;
             // 
             // txtStop
             // 
-            this.txtStop.Location = new System.Drawing.Point(161, 291);
+            this.txtStop.Location = new System.Drawing.Point(171, 324);
             this.txtStop.Name = "txtStop";
             this.txtStop.Size = new System.Drawing.Size(73, 20);
             this.txtStop.TabIndex = 9;
@@ -145,7 +160,8 @@
             // chkStop
             // 
             this.chkStop.AutoSize = true;
-            this.chkStop.Location = new System.Drawing.Point(11, 293);
+            this.chkStop.ForeColor = System.Drawing.Color.White;
+            this.chkStop.Location = new System.Drawing.Point(19, 326);
             this.chkStop.Name = "chkStop";
             this.chkStop.Size = new System.Drawing.Size(144, 17);
             this.chkStop.TabIndex = 11;
@@ -155,15 +171,16 @@
             // cmbAudio
             // 
             this.cmbAudio.FormattingEnabled = true;
-            this.cmbAudio.Location = new System.Drawing.Point(480, 240);
+            this.cmbAudio.Location = new System.Drawing.Point(443, 269);
             this.cmbAudio.Name = "cmbAudio";
-            this.cmbAudio.Size = new System.Drawing.Size(121, 21);
+            this.cmbAudio.Size = new System.Drawing.Size(158, 21);
             this.cmbAudio.TabIndex = 12;
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(334, 243);
+            this.label3.ForeColor = System.Drawing.Color.White;
+            this.label3.Location = new System.Drawing.Point(331, 251);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(140, 13);
             this.label3.TabIndex = 13;
@@ -172,15 +189,16 @@
             // label4
             //
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(-2, 313);
+            this.label4.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(98)))), ((int)(((byte)(218)))), ((int)(((byte)(251)))));
+            this.label4.Location = new System.Drawing.Point(16, 116);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(55, 13);
+            this.label4.Size = new System.Drawing.Size(372, 13);
             this.label4.TabIndex = 14;
-            this.label4.Text = "para LoLo";
+            this.label4.Text = "Dica: marque ocultar para não exibir a tela durante a gravação em andamento.";
             //
             // txtAudioDelay
             //
-            this.txtAudioDelay.Location = new System.Drawing.Point(480, 267);
+            this.txtAudioDelay.Location = new System.Drawing.Point(530, 294);
             this.txtAudioDelay.Name = "txtAudioDelay";
             this.txtAudioDelay.Size = new System.Drawing.Size(72, 20);
             this.txtAudioDelay.TabIndex = 15;
@@ -189,7 +207,8 @@
             // label5
             //
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(334, 269);
+            this.label5.ForeColor = System.Drawing.Color.White;
+            this.label5.Location = new System.Drawing.Point(331, 296);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(105, 13);
             this.label5.TabIndex = 16;
@@ -197,7 +216,7 @@
             //
             // trkQualidade
             //
-            this.trkQualidade.Location = new System.Drawing.Point(15, 197);
+            this.trkQualidade.Location = new System.Drawing.Point(19, 202);
             this.trkQualidade.Maximum = 100;
             this.trkQualidade.Minimum = 1;
             this.trkQualidade.Name = "trkQualidade";
@@ -208,7 +227,8 @@
             // lblQualidadeValor
             //
             this.lblQualidadeValor.AutoSize = true;
-            this.lblQualidadeValor.Location = new System.Drawing.Point(242, 209);
+            this.lblQualidadeValor.ForeColor = System.Drawing.Color.White;
+            this.lblQualidadeValor.Location = new System.Drawing.Point(245, 215);
             this.lblQualidadeValor.Name = "lblQualidadeValor";
             this.lblQualidadeValor.Size = new System.Drawing.Size(116, 13);
             this.lblQualidadeValor.TabIndex = 18;
@@ -217,7 +237,8 @@
             // chkMicrofone
             //
             this.chkMicrofone.AutoSize = true;
-            this.chkMicrofone.Location = new System.Drawing.Point(337, 219);
+            this.chkMicrofone.ForeColor = System.Drawing.Color.White;
+            this.chkMicrofone.Location = new System.Drawing.Point(331, 223);
             this.chkMicrofone.Name = "chkMicrofone";
             this.chkMicrofone.Size = new System.Drawing.Size(114, 17);
             this.chkMicrofone.TabIndex = 19;
@@ -227,16 +248,42 @@
             // cmbMicrofone
             //
             this.cmbMicrofone.FormattingEnabled = true;
-            this.cmbMicrofone.Location = new System.Drawing.Point(480, 216);
+            this.cmbMicrofone.Location = new System.Drawing.Point(443, 221);
             this.cmbMicrofone.Name = "cmbMicrofone";
-            this.cmbMicrofone.Size = new System.Drawing.Size(121, 21);
+            this.cmbMicrofone.Size = new System.Drawing.Size(158, 21);
             this.cmbMicrofone.TabIndex = 20;
-            //
+            // 
+            // chkOcultarAoGravar
+            // 
+            this.chkOcultarAoGravar.AutoSize = true;
+            this.chkOcultarAoGravar.Checked = true;
+            this.chkOcultarAoGravar.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkOcultarAoGravar.ForeColor = System.Drawing.Color.White;
+            this.chkOcultarAoGravar.Location = new System.Drawing.Point(409, 77);
+            this.chkOcultarAoGravar.Name = "chkOcultarAoGravar";
+            this.chkOcultarAoGravar.Size = new System.Drawing.Size(192, 17);
+            this.chkOcultarAoGravar.TabIndex = 21;
+            this.chkOcultarAoGravar.Text = "Ocultar tela enquanto estiver gravando";
+            this.chkOcultarAoGravar.UseVisualStyleBackColor = true;
+            // 
+            // lblAtalhos
+            // 
+            this.lblAtalhos.AutoSize = true;
+            this.lblAtalhos.ForeColor = System.Drawing.Color.White;
+            this.lblAtalhos.Location = new System.Drawing.Point(406, 99);
+            this.lblAtalhos.Name = "lblAtalhos";
+            this.lblAtalhos.Size = new System.Drawing.Size(183, 26);
+            this.lblAtalhos.TabIndex = 22;
+            this.lblAtalhos.Text = "Atalhos:\r\nF8 iniciar | F9 parar | Ctrl+Shift+H mostrar";
+            // 
             // Form1
-            //
+            // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(615, 326);
+            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(24)))), ((int)(((byte)(32)))), ((int)(((byte)(47)))));
+            this.ClientSize = new System.Drawing.Size(622, 365);
+            this.Controls.Add(this.lblAtalhos);
+            this.Controls.Add(this.chkOcultarAoGravar);
             this.Controls.Add(this.cmbMicrofone);
             this.Controls.Add(this.chkMicrofone);
             this.Controls.Add(this.lblQualidadeValor);
@@ -257,8 +304,11 @@
             this.Controls.Add(this.btnParar);
             this.Controls.Add(this.btnIniciar);
             this.Controls.Add(this.label1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
             this.Name = "Form1";
-            this.Text = "Form1";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "Gravador de Tela Pro";
             ((System.ComponentModel.ISupportInitialize)(this.trkQualidade)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -287,6 +337,7 @@
         private System.Windows.Forms.Label lblQualidadeValor;
         private System.Windows.Forms.CheckBox chkMicrofone;
         private System.Windows.Forms.ComboBox cmbMicrofone;
+        private System.Windows.Forms.CheckBox chkOcultarAoGravar;
+        private System.Windows.Forms.Label lblAtalhos;
     }
 }
-

--- a/Form1.cs
+++ b/Form1.cs
@@ -28,6 +28,17 @@ namespace GravadorDeTela
         private WinFormsTimer _segmentTimer;
         private int _segmentIndex;
         private bool _isStopping;
+        private bool _hotkeysRegistradas;
+
+        private const int HOTKEY_ID_INICIAR = 0x1001;
+        private const int HOTKEY_ID_PARAR = 0x1002;
+        private const int HOTKEY_ID_MOSTRAR = 0x1003;
+        private const uint MOD_CONTROL = 0x0002;
+        private const uint MOD_SHIFT = 0x0004;
+        private const uint VK_F8 = 0x77;
+        private const uint VK_F9 = 0x78;
+        private const uint VK_H = 0x48;
+        private const int WM_HOTKEY = 0x0312;
 
         // ===== Classe interna para popular o Combo =====
         private class AudioDeviceItem
@@ -40,6 +51,7 @@ namespace GravadorDeTela
         public Form1()
         {
             InitializeComponent();
+            KeyPreview = true;
 
             // Estado inicial UI
             btnParar.Enabled = false;
@@ -75,11 +87,85 @@ namespace GravadorDeTela
             // Carregar dispositivos de áudio dshow
             Shown += async (s, e) => await CarregarDispositivosAudio();
             FormClosing += Form1_FormClosing;
+
+            RegistrarAtalhosGlobais();
         }
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool UnregisterHotKey(IntPtr hWnd, int id);
 
         private void Form1_FormClosing(object sender, FormClosingEventArgs e)
         {
             CleanupRecordingResources(stopRecorder: true, disposeRecorder: true);
+            DesregistrarAtalhosGlobais();
+        }
+
+        protected override void WndProc(ref Message m)
+        {
+            if (m.Msg == WM_HOTKEY)
+            {
+                int id = m.WParam.ToInt32();
+                if (id == HOTKEY_ID_INICIAR && btnIniciar.Enabled)
+                {
+                    btnIniciar.PerformClick();
+                }
+                else if (id == HOTKEY_ID_PARAR && btnParar.Enabled)
+                {
+                    btnParar.PerformClick();
+                }
+                else if (id == HOTKEY_ID_MOSTRAR)
+                {
+                    MostrarJanela();
+                }
+            }
+
+            base.WndProc(ref m);
+        }
+
+        private void RegistrarAtalhosGlobais()
+        {
+            if (_hotkeysRegistradas)
+                return;
+
+            bool iniciarOk = RegisterHotKey(Handle, HOTKEY_ID_INICIAR, 0, VK_F8);
+            bool pararOk = RegisterHotKey(Handle, HOTKEY_ID_PARAR, 0, VK_F9);
+            bool mostrarOk = RegisterHotKey(Handle, HOTKEY_ID_MOSTRAR, MOD_CONTROL | MOD_SHIFT, VK_H);
+
+            _hotkeysRegistradas = iniciarOk && pararOk && mostrarOk;
+            if (!_hotkeysRegistradas)
+                Log("Falha ao registrar um ou mais atalhos globais (F8/F9/Ctrl+Shift+H).");
+        }
+
+        private void DesregistrarAtalhosGlobais()
+        {
+            if (!_hotkeysRegistradas)
+                return;
+
+            UnregisterHotKey(Handle, HOTKEY_ID_INICIAR);
+            UnregisterHotKey(Handle, HOTKEY_ID_PARAR);
+            UnregisterHotKey(Handle, HOTKEY_ID_MOSTRAR);
+            _hotkeysRegistradas = false;
+        }
+
+        private void OcultarJanelaDuranteGravacao()
+        {
+            if (!chkOcultarAoGravar.Checked)
+                return;
+
+            this.Hide();
+            ShowInTaskbar = false;
+        }
+
+        private void MostrarJanela()
+        {
+            ShowInTaskbar = true;
+            this.Show();
+            WindowState = FormWindowState.Normal;
+            this.BringToFront();
+            this.Activate();
         }
 
         private void trkQualidade_Scroll(object sender, EventArgs e)
@@ -124,6 +210,7 @@ namespace GravadorDeTela
         private void FinalizarUI()
         {
             this.Cursor = Cursors.Default;
+            MostrarJanela();
             btnIniciar.Enabled = true;
             btnParar.Enabled = false;
             progressBar1.Visible = false;
@@ -136,6 +223,7 @@ namespace GravadorDeTela
             chkStop.Enabled = true;
             txtStop.Enabled = chkStop.Checked;
             txtAudioDelay.Enabled = true;
+            chkOcultarAoGravar.Enabled = true;
         }
 
         private void CleanupRecordingResources(bool stopRecorder, bool disposeRecorder)
@@ -647,10 +735,12 @@ namespace GravadorDeTela
                 txtStop.Enabled = false;
                 txtSegmentacao.Enabled = false;
                 txtAudioDelay.Enabled = false;
+                chkOcultarAoGravar.Enabled = false;
 
                 // A gravação já foi iniciada; mantém o cursor normal para não parecer "travado".
                 this.Cursor = Cursors.Default;
                 AtualizaStatus("Gravando...", marquee: false);
+                OcultarJanelaDuranteGravacao();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
### Motivation
- Tornar a interface mais moderna e produtiva para iniciar/parar gravações rapidamente sem precisar do foco da janela. 
- Permitir gravar sem deixar a janela visível (modo oculto) para fluxos automáticos ou captura discreta.

### Description
- Atualiza o layout visual do formulário (`Form1.Designer.cs`) para tema escuro, textos/posicionamento ajustados, botões com rótulos de atalhos e nova checkbox `chkOcultarAoGravar` e label `lblAtalhos`.
- Implementa atalhos globais via `RegisterHotKey`/`UnregisterHotKey` e tratamento em `WndProc` em `Form1.cs` para `F8` (iniciar), `F9` (parar) e `Ctrl+Shift+H` (mostrar janela).
- Adiciona lógica para esconder a janela ao iniciar a gravação (`OcultarJanelaDuranteGravacao`) e trazê-la de volta ao finalizar (`MostrarJanela`/`FinalizarUI`), além de habilitar/desabilitar o checkbox enquanto grava.

### Testing
- Tentativa de build com `dotnet build GravadorDeTela.sln` foi executada e falhou no ambiente de CI porque o comando `dotnet` não está disponível.
- Tentativa de build com `msbuild GravadorDeTela.sln /t:Build /p:Configuration=Release` foi executada e falhou no ambiente de CI porque o comando `msbuild` não está disponível.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69939b3741308321b15a376458806363)